### PR TITLE
add .codeclimate.yml with .mjs config for ESLint

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,59 @@
+version: "2"
+
+checks: 
+  argument-count: 
+    enabled: true
+  
+  complex-logic: 
+    enabled: true
+  
+  file-lines: 
+    enabled: true
+  
+  identical-code: # language-specific defaults. an override will affect all languages.
+    enabled: true
+  
+  method-complexity: 
+    enabled: true
+  
+  method-count: 
+    enabled: true
+  
+  method-lines: 
+    enabled: false
+  
+  nested-control-flow: 
+    enabled: true
+  
+  return-statements: 
+    enabled: false
+  
+  similar-code: # language-specific defaults. an override will affect all languages.
+    enabled: true
+  
+exclude_patterns: 
+  - config/
+  - db/
+  - dist/
+  - features/
+  - "**/node_modules/"
+  - script/
+  - "**/spec/"
+  - "**/test/"
+  - "**/tests/"
+  - Tests/
+  - "**/vendor/"
+  - "**/*_test.go"
+  - "**/*.d.ts"
+  - test.js
+  - index.js
+
+plugins: 
+  eslint:
+    enabled: true
+    config:
+      extensions:
+      - .es6
+      - .js
+      - .jsx
+      - .mjs


### PR DESCRIPTION
Hi @MikeKovarik -

Emily with Code Climate Support. There are more details in the email, but this PR configures the **ESLint plugin** to check **.mjs files**. 

- More docs on advanced configs for your analysis:  [Advanced Configuration](https://docs.codeclimate.com/v1.0/docs/advanced-configuration) and [ESLint plugin](https://docs.codeclimate.com/v1.0/docs/eslint).

Let me know if you have any other questions. Thanks!