### PR TITLE
Auto detection of localized messages 

### DIFF
--- a/src/Registry.mjs
+++ b/src/Registry.mjs
@@ -37,7 +37,8 @@ export class Registry {
 
 Registry.VALUES = '$values'
 Registry.DEFAULT = ''
-Registry.DEFAULT_VERBOSE = '(Default)'
+Registry.DEFAULT_VERBOSE = null
+Registry.VALUENOTSET_VERBOSE = null
 
 // Only names and paths are affected, not the data
 Registry.lowercase = true

--- a/src/get.mjs
+++ b/src/get.mjs
@@ -278,9 +278,9 @@ function processValueLine(line, options) {
 	// value line starts with 4 spaces and consists of three items that are also spaces by 4 spaces.
 	// WARNING: Do not trim. Lines only start with 4 spaces, they don't end with 4 spaces unsless the value is empty string.
 	var [name, type, data] = line.slice(4).split('    ')
-	if (name === '(Default)')
+	if (name === Registry.DEFAULT_VERBOSE)
 		name = Registry.DEFAULT
-	if (data === '(value not set)')
+	if (data === Registry.VALUENOTSET_VERBOSE)
 		data = undefined
 	else if (options.lowercase)
 		name = name.toLowerCase()


### PR DESCRIPTION
In some cases **rage-edit** expects `(Default)` and `(value not set)` values which are different in non-English windows.

This request adds auto detection for those values so `npm run test` is green on different machines again :)