### PR TITLE
Make '.setKey()' create true undefined values instead of empty string

### DIFF
--- a/src/set.mjs
+++ b/src/set.mjs
@@ -26,6 +26,8 @@ Registry.setKey = async function(path) {
 	// Note: Not returning, the output of the reg command saying 'operation completed successfully'.
 	//       Only await the process to finish. If any error occurs, the thrown error will bubble up.
 	await execute(['add', path, '/f'])
+	// 'reg.exe add' always creates/overrides '(default)' item with empty string (not undefined value). This command makes '(default)' undefined.
+	await execute(['delete', path, '/ve', '/f'])
 }
 
 


### PR DESCRIPTION
Pull request for #11 